### PR TITLE
Classes Test, Rename & Remove Leftover "main::"

### DIFF
--- a/t/classes/08auto.t
+++ b/t/classes/08auto.t
@@ -39,7 +39,7 @@ use Test::More;
 
 can_ok 'MyClass', 'new';
 my $m = new_ok 'MyClass';
-is ref($m), 'MyClass', 'Our "MyClass" is a "main::MyClass"';
+is ref($m), 'MyClass', 'Our "MyClass" is a "MyClass"';
 
 can_ok 'Foo::Bar::MyClass', 'new';
 my $fb = new_ok 'Foo::Bar::MyClass';


### PR DESCRIPTION
Renamed "t/classes/09auto.t" to "t/classes/08auto.t".

Removed now-incorrect "main::" from test message.
