### PR TITLE
When using clang, prefer clang++ over g++

### DIFF
--- a/inc/ILCPPConfig/CompilerGuess.pm
+++ b/inc/ILCPPConfig/CompilerGuess.pm
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 use ExtUtils::CppGuess;
 use Exporter;
+use Config;
 
 our @ISA       = 'Exporter';
 our @EXPORT_OK = 'guess_compiler';
@@ -27,7 +28,11 @@ sub guess_compiler {
     $guesser = ExtUtils::CppGuess->new;
     %configuration = $guesser->module_build_options;
     if( $guesser->is_gcc ) {
-      $cc_guess = 'g++';
+      if( $Config{cc} eq 'clang' ) {
+        $cc_guess = 'clang++';
+      } else {
+        $cc_guess = 'g++';
+      }
     }
     elsif ( $guesser->is_msvc ) {
       $cc_guess = 'cl';

--- a/inc/ILCPPConfig/OldCompilerGuess.pm
+++ b/inc/ILCPPConfig/OldCompilerGuess.pm
@@ -94,6 +94,10 @@ sub guess_compiler {
     $cc_guess   = 'g++';
     $libs_guess = '-lstdc++';
   }
+  
+  if( $cc_guess eq 'g++' && $Config{cc} eq 'clang') {
+    $cc_guess = 'clang++';
+  }
 
   return( $cc_guess, $libs_guess );
 }


### PR DESCRIPTION
On my system gcc / g++ is much older than the clang / clang++ used to build Perl, and does not support the `-fstack-protector-strong` option that was apparently used when building Perl.  I suggest using `clang++` instead of `g++` when the `$Config{cc}` is `clang`.  This PR works for me, although I am happy to adjust it and test if you have a preferred solution.  I am also happy to coordinate with `ExtUtils::CppGuess` if you think detection logic should go in there.  What follows is the test failure that I get without this patch.

```
twin% prove -b t/02basic.t
t/02basic.t .. Running Mkbootstrap for _02basic_t_bc90 ()
chmod 644 "_02basic_t_bc90.bs"
"/home/ollisg/perl5/perlbrew/perls/perl-5.23.1t/bin/perl5.23.1" "/home/ollisg/perl5/perlbrew/perls/perl-5.23.1t/lib/5.23.1/ExtUtils/xsubpp"  -typemap "/home/ollisg/perl5/perlbrew/perls/perl-5.23.1t/lib/5.23.1/ExtUtils/typemap" -typemap "/home/ollisg/.cpanm/work/1438655477.4985/Inline-CPP-0.71/_Inline/build/_02basic_t_bc90/CPP.map"   _02basic_t_bc90.xs > _02basic_t_bc90.xsc && mv _02basic_t_bc90.xsc _02basic_t_bc90.c
g++ -xc++  -D_FILE_OFFSET_BITS=64 -c  -I"/home/ollisg/.cpanm/work/1438655477.4985/Inline-CPP-0.71/t" -D_REENTRANT -D_GNU_SOURCE -fno-strict-aliasing -pipe -fstack-protector-strong -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2 -O2   -DVERSION=\"0.00\" -DXS_VERSION=\"0.00\" -fPIC "-I/home/ollisg/perl5/perlbrew/perls/perl-5.23.1t/lib/5.23.1/x86_64-linux-thread-multi/CORE"   _02basic_t_bc90.c
g++: error: unrecognized command line option ‘-fstack-protector-strong’
make: *** [_02basic_t_bc90.o] Error 1

A problem was encountered while attempting to compile and install your Inline
CPP code. The command that failed was:
  "make > out.make 2>&1" with error code 2

The build directory was:
/home/ollisg/.cpanm/work/1438655477.4985/Inline-CPP-0.71/_Inline/build/_02basic_t_bc90

To debug the problem, cd to the build directory, and inspect the output files.

Environment PATH = '/home/ollisg/opt/rust/1.0.0/bin:/home/ollisg/opt/sbt/bin:/home/ollisg/opt/scala/2.11.1/bin:/home/ollisg/opt/sbt/bin:/home/ollisg/opt/scala/2.11.1/bin:/home/ollisg/opt/clang/3.6.1/bin:/home/ollisg/.perlbrew/libs/perl-5.23.1t@dev/bin:/home/ollisg/perl5/perlbrew/bin:/home/ollisg/perl5/perlbrew/perls/perl-5.23.1t/bin:/home/ollisg/opt/rust/1.0.0/bin:/home/ollisg/opt/sbt/bin:/home/ollisg/opt/scala/2.11.1/bin:/home/ollisg/opt/clang/3.6.1/bin:/home/ollisg/opt/clang/3.4.2/bin:/home/ollisg/opt/rust/1.0.0alpha/bin:/home/ollisg/bin:/home/ollisg/opt/rust/0.9/bin:/home/ollisg/opt/pkg-config/0.28/bin:/home/ollisg/opt/clang/3.4/bin:/usr/lib/ccache:/usr/local/bin:/usr/bin:/bin:/usr/bin/X11:/usr/games'
Environment PATH_WITHOUT_PERLBREW = '/home/ollisg/opt/rust/1.0.0/bin:/home/ollisg/opt/sbt/bin:/home/ollisg/opt/scala/2.11.1/bin:/home/ollisg/opt/clang/3.6.1/bin:/home/ollisg/opt/clang/3.4.2/bin:/home/ollisg/opt/rust/1.0.0alpha/bin:/home/ollisg/bin:/home/ollisg/opt/rust/0.9/bin:/home/ollisg/opt/pkg-config/0.28/bin:/home/ollisg/opt/clang/3.4/bin:/usr/lib/ccache:/usr/local/bin:/usr/bin:/bin:/usr/bin/X11:/usr/games'
 at t/02basic.t line 34.
        ...propagated at /home/ollisg/.perlbrew/libs/perl-5.23.1t@dev/lib/perl5/Inline/C.pm line 869.
BEGIN failed--compilation aborted at t/02basic.t line 34.
# Looks like your test exited with 2 before it could output anything.
t/02basic.t .. Dubious, test returned 2 (wstat 512, 0x200)
Failed 12/12 subtests

Test Summary Report
-------------------
t/02basic.t (Wstat: 512 Tests: 0 Failed: 0)
  Non-zero exit status: 2
  Parse errors: Bad plan.  You planned 12 tests but ran 0.
Files=1, Tests=0,  1 wallclock secs ( 0.02 usr  0.01 sys +  0.80 cusr  0.07 csys =  0.90 CPU)
Result: FAIL
```