### PR TITLE
Fix test failure due to Windows style directory separators.

### DIFF
--- a/t/classes/07conflict_avoid.t
+++ b/t/classes/07conflict_avoid.t
@@ -48,9 +48,9 @@ close $fhb;
 
 eval qq[
   use Inline CPP =>
-    "$tdir/Foo__Qux__MyClass.c", 
-    filters   => 'Preprocess', 
-    namespace => 'Foo', 
+    '$tdir/Foo__Qux__MyClass.c',
+    filters   => 'Preprocess',
+    namespace => 'Foo',
     classes   => {
       'Foo__Bar__MyClass' => 'Bar::MyClass',
       'Foo__Qux__MyClass' => 'Qux::MyClass'


### PR DESCRIPTION
This fixes the following with 0.72 on Windows. See also #30.

<pre>C:\...\Inline-CPP> prove -vb t\classes\07conflict_avoid.t
t\classes\07conflict_avoid.t .. Unrecognized escape \s passed through at (eval 13) line 3.
Unrecognized escape \A passed through at (eval 13) line 3.
Unrecognized escape \T passed through at (eval 13) line 3.
Filters7744.c


not ok 1 - Foo::Bar::MyClass->can('new')#   Failed test 'Foo::Bar::MyClass->can('new')'

#   at t\classes\07conflict_avoid.t line 71.
#     Foo::Bar::MyClass->can('new') failed
not ok 2 - Foo::Bar::MyClass->new() died
#   Failed test 'Foo::Bar::MyClass->new() died'

#   at t\classes\07conflict_avoid.t line 73.
#     Error was:  Can't locate object method "new" via package "Foo::Bar::MyClass" (perhaps you forgot to load "Foo::Bar::MyClass"?) at C:/opt/perl-5.22.0/lib/
Test/More.pm line 690.
not ok 3 - Our "MyClass" is a "Foo::Bar::MyClass"
#   Failed test 'Our "MyClass" is a "Foo::Bar::MyClass"'

#   at t\classes\07conflict_avoid.t line 75.
#          got: ''
#     expected: 'Foo::Bar::MyClass'
not ok 4 - Foo::Qux::MyClass->can('new')
#   Failed test 'Foo::Qux::MyClass->can('new')'

#   at t\classes\07conflict_avoid.t line 77.
#     Foo::Qux::MyClass->can('new') failed
not ok 5 - Foo::Qux::MyClass->new() died
#   Failed test 'Foo::Qux::MyClass->new() died'

#   at t\classes\07conflict_avoid.t line 79.
#     Error was:  Can't locate object method "new" via package "Foo::Qux::MyClass" (perhaps you forgot to load "Foo::Qux::MyClass"?) at C:/opt/perl-5.22.0/lib/
Test/More.pm line 690.
not ok 6 - Our "MyClass" is a "Foo::Qux::MyClass"
#   Failed test 'Our "MyClass" is a "Foo::Qux::MyClass"'

#   at t\classes\07conflict_avoid.t line 81.
#          got: ''
#     expected: 'Foo::Qux::MyClass'
Can't call method "fetch" on an undefined value at t\classes\07conflict_avoid.t line 83.
# Tests were run but no plan was declared and done_testing() was not seen.
# Looks like your test exited with 2 just after 6.
Dubious, test returned 2 (wstat 512, 0x200)
Failed 6/6 subtests

Test Summary Report
-------------------
t\classes\07conflict_avoid.t (Wstat: 512 Tests: 6 Failed: 6)
  Failed tests:  1-6
  Non-zero exit status: 2
  Parse errors: No plan found in TAP output
Files=1, Tests=6,  5 wallclock secs ( 0.06 usr +  0.01 sys =  0.08 CPU)
Result: FAIL</pre>