### PR TITLE
support perl 5.8.1 since Pegex does again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: perl
 sudo: false
 matrix:
   include:
-    - perl: "5.10.0"
+    - perl: "5.8.1"
     - perl: "5.26"
       env: RELEASE_TESTING=1
     # separate from release testing else cover_db blows up xt/manifest.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -101,7 +101,6 @@ WriteMakefile(
           'Test::Pod::Coverage' => '1.00',
           'Test::Kwalitee' => 0,
           'Test::CPAN::Changes' => 0,
-          'Test::CheckManifest' => '0.9',
         },
       },
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ END_TEST_CPP
 
 my %PREREQ_PM = (
   'Inline'            => '0.78',
-  'Inline::C'         => '0.67',
+  'Inline::C'         => '0.79', # supports 5.8.1
   'Parse::RecDescent' => '0',
   'Carp'              => '0',
 );
@@ -106,7 +106,7 @@ WriteMakefile(
       },
     },
   },
-  MIN_PERL_VERSION => '5.010000',  # Inline::C~0.77 requires 5.10.0.
+  MIN_PERL_VERSION => '5.008001',
   test  => {RECURSIVE_TEST_FILES => 1},
   clean => {FILES => join q{ }, $CPP_Config_path, qw{
     _Inline/            t/_Inline

--- a/xt/manifest.t
+++ b/xt/manifest.t
@@ -1,13 +1,12 @@
 use strict;
 use warnings;
 use Test::More;
+use ExtUtils::Manifest;
 
 unless ( $ENV{RELEASE_TESTING} ) {
     plan( skip_all => "Author tests not required for installation" );
 }
+plan tests => 2;
 
-my $min_tcm = 0.9;
-eval "use Test::CheckManifest $min_tcm";
-plan skip_all => "Test::CheckManifest $min_tcm required" if $@;
-
-ok_manifest();
+is_deeply [ ExtUtils::Manifest::manicheck() ], [], 'missing';
+is_deeply [ ExtUtils::Manifest::filecheck() ], [], 'extra';


### PR DESCRIPTION
Moves minimum Perl back to 5.8.1. This won't work right until `Inline::C` merges and releases https://github.com/ingydotnet/inline-c-pm/pull/71.