### PR TITLE
support perl 5.8.1 since Pegex does again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: perl
 sudo: false
 matrix:
   include:
-    - perl: "5.10.0"
+    - perl: "5.8.1"
     - perl: "5.26"
       env: RELEASE_TESTING=1
     # separate from release testing else cover_db blows up xt/manifest.t

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ END_TEST_CPP
 
 my %PREREQ_PM = (
   'Inline'            => '0.78',
-  'Inline::C'         => '0.67',
+  'Inline::C'         => '0.79', # supports 5.8.1
   'Parse::RecDescent' => '0',
   'Carp'              => '0',
 );
@@ -105,7 +105,7 @@ WriteMakefile(
       },
     },
   },
-  MIN_PERL_VERSION => '5.010000',  # Inline::C~0.77 requires 5.10.0.
+  MIN_PERL_VERSION => '5.008001',
   test  => {RECURSIVE_TEST_FILES => 1},
   clean => {FILES => join q{ }, $CPP_Config_path, qw{
     _Inline/            t/_Inline


### PR DESCRIPTION
Moves minimum Perl back to 5.8.1. This won't work right until Inline::C merges and releases ingydotnet/inline-c-pm#71. Re-opening of #44.