### PR TITLE
virtual dtor causes bad xs code to be generated (test case and possible fix)

### DIFF
--- a/lib/Inline/CPP/Parser/RecDescent.pm
+++ b/lib/Inline/CPP/Parser/RecDescent.pm
@@ -102,7 +102,7 @@ sub grammar {
 { use Data::Dumper; }
 
 {
-  sub fixkey { &$Inline::CPP::Parser::RecDescent::fixkey }
+    sub fixkey { &$Inline::CPP::Parser::RecDescent::fixkey }
 }
 
 {
@@ -302,10 +302,10 @@ method_def: operator <commit> method_imp
                $item[1];
             }
 
-          | IDENTIFIER '(' <commit> <leftop: arg ',' arg>(s?) ')' method_imp
+          | ('virtual')(?) IDENTIFIER '(' <commit> <leftop: arg ',' arg>(s?) ')' method_imp
             {
-#         print "con-/de-structor found: $item[1]\n";
-              {name => $item[1], args => $item{__DIRECTIVE2__}, abstract => ${$item{method_imp}} };
+#         print "con-/de-structor found: $item[2]\n";
+              {name => $item[2], args => $item{__DIRECTIVE2__}, abstract => ${$item{method_imp}} };
             }
           | return_type IDENTIFIER '(' <leftop: arg ',' arg>(s?) ')' method_imp
             {
@@ -454,7 +454,7 @@ comment: m{\s* // [^\n]* \n }x
 # be parsed correctly here.
 modifier: tmod
         | smod { ++$thisparser->{data}{smod}{$item[1]}; ''}
-    | nmod { '' }
+        | nmod { '' }
 tmod: 'unsigned' # | 'long' | 'short'
 smod: 'const' | 'static'
 nmod: 'extern' | 'virtual' | 'mutable' | 'volatile' | 'inline'

--- a/t/grammar/05virt.t
+++ b/t/grammar/05virt.t
@@ -14,12 +14,26 @@ class Foo {
 
     virtual const char *get_data_ro() { return "Hello Sally!\n"; }
 };
+
+class Foo2 {
+  public:
+    Foo2() { }
+    virtual ~Foo2() { }
+
+    virtual const char *get_data_ro() { return "Hello Sue!\n"; }
+};
+
 END
 
 
 is(
     Foo->new->get_data_ro, "Hello Sally!\n",
     "Define and invoke virtual function."
+);
+
+is(
+    Foo2->new->get_data_ro, "Hello Sue!\n",
+    "Use class with virtual dtor."
 );
 
 done_testing();


### PR DESCRIPTION
Please see https://github.com/daoswald/Inline-CPP/issues/53

I changed a test case (grammar/05virt.t) to test having a virtual dtor.  This test now fails when using master.

Implemented a _possible_ fix in CPP/Parser/RecDescent.pm 
