### PR TITLE
Added test case for func returning 'const char *' (currently fails)

### DIFF
--- a/t/grammar/08anon.t
+++ b/t/grammar/08anon.t
@@ -17,11 +17,14 @@ Foo::Foo(int a, int b) {
 
 int add(int, int);
 int add(int a, int b) { return a + b; }
+const char *getstr() { return "Hello Bob!"; }
 
 END
 
 new_ok( 'Foo', [ 10, 11 ] );
 
-is( add( 2, 3 ), 5, "Simple function." );
+is( add( 2, 3 ), 5, "Simple function returning int." );
+
+is( getstr(), "Hello Bob!", "Simple function returning const char *." );
 
 done_testing();


### PR DESCRIPTION
'const char *'.   This currently does not work.

It might be related to typemaps.  The compile errors look like this:

  error: invalid conversion from ‘const char*’ to ‘char*’ [-fpermissive]
    RETVAL = myfunc();
             ~~~~~~^~

(only functions don't work; methods returning 'const char *' work okay).