### PR TITLE
Ctor args are corrupted if declared with default values

### DIFF
--- a/t/grammar/10struct.t
+++ b/t/grammar/10struct.t
@@ -23,7 +23,7 @@ struct Fizzle {
 
 END
 
-$SIG{__WARN__} = sub{ die "\nWARNING TRAPPED:",@_ };
+$SIG{__WARN__} = sub{ warn "\nWARNING TRAPPED:",@_; fail };
 
 my $o = new_ok( 'Fizzle' );
 
@@ -33,5 +33,8 @@ is(
 );
 
 my $o1 = Fizzle->new(42, 6.75, 123);
+is($o1->get_q, 42, "Struct with passed ctor args (int)");
+is($o1->get_foozle, 6.75, "Struct with passed ctor args (double)");
+is($o1->get_quack, 123, "Struct with passed ctor args (another int)");
 
 done_testing();

--- a/t/grammar/10struct.t
+++ b/t/grammar/10struct.t
@@ -23,11 +23,15 @@ struct Fizzle {
 
 END
 
+$SIG{__WARN__} = sub{ die "\nWARNING TRAPPED:",@_ };
+
 my $o = new_ok( 'Fizzle' );
 
 is(
     $o->get_q, 0,
     "Struct with public member function."
 );
+
+my $o1 = Fizzle->new(42, 6.75, 123);
 
 done_testing();


### PR DESCRIPTION
This pull request modifies a test case to demonstrate the bug described at
https://github.com/daoswald/Inline-CPP/issues/58